### PR TITLE
Use lastest ex_hash_ring

### DIFF
--- a/lib/roulette/cluster_chooser.ex
+++ b/lib/roulette/cluster_chooser.ex
@@ -1,6 +1,7 @@
 defmodule Roulette.ClusterChooser do
 
   alias Roulette.Util.IndexList
+  alias ExHashRing.HashRing
 
   def choose(module, topic) do
     [ring, hosts] = FastGlobal.get(module)

--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule Roulette.Mixfile do
       {:ex_doc, "~> 0.15", only: :dev, runtime: false},
       {:credo, "~> 0.3", only: :dev, runtime: false},
       {:mock, "~> 0.3.0", only: :test},
-      {:ex_hash_ring, "~> 1.0"},
+      {:ex_hash_ring, "~> 3.0"},
       {:fastglobal, "~> 1.0"},
       {:gnat, "~> 0.4.1"},
       {:poolboy, "~> 1.5"}

--- a/mix.lock
+++ b/mix.lock
@@ -3,7 +3,7 @@
   "credo": {:hex, :credo, "0.9.3", "76fa3e9e497ab282e0cf64b98a624aa11da702854c52c82db1bf24e54ab7c97a", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:poison, ">= 0.0.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "ex_hash_ring": {:hex, :ex_hash_ring, "1.0.0", "9eb081ecac43435937b0a00db08477071f4183a137db28700b06fe424d0e4c8f", [:mix], [], "hexpm"},
+  "ex_hash_ring": {:hex, :ex_hash_ring, "3.0.0", "da32c83d7c6d964b9537eb52f27bad0a3a6f7012efdc2749e11a5f268b120b6b", [:mix], [], "hexpm"},
   "fastglobal": {:hex, :fastglobal, "1.0.0", "f3133a0cda8e9408aac7281ec579c4b4a8386ce0e99ca55f746b9f58192f455b", [:mix], [], "hexpm"},
   "gnat": {:hex, :gnat, "0.4.1", "5a8f06f462690567c12b43e5f3a66dd7243cc2af1679114167d0f3156d0d45a5", [:mix], [{:poison, "~> 3.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
   "gproc": {:hex, :gproc, "0.6.1", "4579663e5677970758a05d8f65d13c3e9814ec707ad51d8dcef7294eda1a730c", [:rebar3], [], "hexpm"},


### PR DESCRIPTION
It was discovered that `libring` and `ex_hash_ring` had conflicting modules
names which caused issues for a user that ended up with both through transitive
dependencies.

https://github.com/discordapp/ex_hash_ring/issues/3
https://github.com/bitwalker/libring/issues/15

This diff bumps you to the latest version of `ex_hash_ring` which now
has a namespace to avoid conflict.